### PR TITLE
Add KSP_VERSION_MAX

### DIFF
--- a/ShowFPS.version
+++ b/ShowFPS.version
@@ -16,5 +16,10 @@
     "MAJOR": 1,
     "MINOR": 4,
     "PATCH": 1
+  },
+  "KSP_VERSION": {
+    "MAJOR": 1,
+    "MINOR": 4,
+    "PATCH": 99
   }
 }


### PR DESCRIPTION
I don't know if 1.4.99 is entirely appropriate here. I do know that it appears to work fine in 1.4.3, so I'm extrapolating out to all patch versions. :simple_smile: