### PR TITLE
Raise max FPS limit for graph to 600

### DIFF
--- a/ShowFPS/Graph.cs
+++ b/ShowFPS/Graph.cs
@@ -237,7 +237,7 @@ namespace ShowFPS
             windowId = Guid.NewGuid().GetHashCode();
             windowTitle = "Show FPS";
 
-            valCycle = new float[] { 5, 10, 15, 30, 40, 50, 60, 70, 80, 90, 100, 120, 150, 200 };
+            valCycle = new float[] { 5, 10, 15, 30, 40, 50, 60, 70, 80, 90, 100, 120, 150, 200, 250, 300, 350, 400, 450, 500, 550, 600 };
             numScales = valCycle.Length;
 
             helpWinPos.Set(40, 40, 500, 100);


### PR DESCRIPTION
Having a 200 FPS cap for the graph is somewhat limiting. Some monitors exist that can hit over [500hz](https://www.gamesradar.com/hardware/tvs-monitors/aoc-agon-pro-ag246fk-review/). While I certainly can't get even near to that, (my monitor is only 180), my GPU is able to push past 200 FPS if I uncap KSP, in which case the graph becomes useless for determining the performance impact of certain mods. This PR raises the limit to 600.


Before:
![image](https://github.com/user-attachments/assets/175906cb-4039-41eb-8293-0fc9c4f3ef32)

After:
![image](https://github.com/user-attachments/assets/f4528cd4-0857-4c11-9235-8c5a85235791)

