### PR TITLE
Hide FPS counter on F2 press

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,7 @@ Just copy into your KSP's GameData directory.
 Features
 --------
 
-Simple movable framerate counter on your screen. For those that 
-don't have access to the usual Windows utilities for display it, like Linux users.
+Simple movable framerate counter on your screen. For those that don't have access to the usual Windows utilities for display it, like Linux users.
 
 Graph window to show FPS over time. Graph shows current FPS, a moving average of the FPS, and the Simulation rate (ie: how much is it lagging, related to yellow/red clocking). It can also show a line of a normal symrate (no lagging).
 Along the left of the graph will be a scale for the FPS. Along the right will be a scale for the symrate.

--- a/README.md
+++ b/README.md
@@ -18,39 +18,36 @@ Just copy into your KSP's GameData directory.
 Features
 --------
 
-Simple framerate counter in the top right corner of the screen. For those that 
+Simple movable framerate counter on your screen. For those that 
 don't have access to the usual Windows utilities for display it, like Linux users.
 
-Graph window to show FPS over time.  Graph shows current FPS, a moving average of the FPS, and the Simulation rate (ie:  how much is it lagging, related to yellow/red clocking).  It can also show a line of a normal sim rate (no lagging).
-Along the left of the graph will be a scale for the FPS.  Along the right will be a scale for the symrate
+Graph window to show FPS over time. Graph shows current FPS, a moving average of the FPS, and the Simulation rate (ie: how much is it lagging, related to yellow/red clocking). It can also show a line of a normal symrate (no lagging).
+Along the left of the graph will be a scale for the FPS. Along the right will be a scale for the symrate.
 
 Usage
 -----
 
-Just press F8 for toggle the FPS counter on and off. Pressing Ctrl+F8
-while is enabled will also do a very minimalist benchmark, calculating the 
-avegare FPS and the lowest count.
+Just press F8 for toggle the FPS counter on and off. Clicking on the toolbar will show the Graph.
 
-You can click and drag the counter anywhere you like. You might also change
-the default key F8 to anything you like in the settings.cfg file.
+You can click and drag the counter anywhere you like. You can also change the default key F8 to anything you like in the settings.cfg file.
 
 
 Graph Window Controls
 
 	Buttons
 		Refresh					Redraw the graph
-		Clear					Clear all data form graph 
-		Rescale					Rescale the graph to fix all the data.
+		Clear					Clear all data from graph 
+		Rescale					Rescale the graph to fix all of the data.
 
 	Toggles
 		Show Max Symrate		Show a grey line of what the normal (no losses) symrate should be
 		Periodic auto-rescale	Will automatically rescale the graph once a minute, if necessary
 
 	Sliders
-		Transparency			Lets the background of the graph be transparent.  Only takes effect on newly drawn lines or by resizing the graph
+		Transparency			Lets the background of the graph be transparent. Only takes effect on newly drawn lines or by resizing the graph
 		Frequency				How often to plot a datapoint
 
 	Resizer
-		A resizer control is at the lower right of the screen.  Click and drag it to resize the window
+		A resizer control is at the lower right of the screen. Click and drag it to resize the window
 
 The toggle and slider settings are saved between game sessions

--- a/ShowFPS/ShowFPS.cs
+++ b/ShowFPS/ShowFPS.cs
@@ -73,14 +73,14 @@ namespace ShowFPS
             GameEvents.onHideUI.Add(HideGUI);
         }
 
-        void ShowGUI()
-        {
-            isKSPGUIActive = true;
-        }
+        void ShowGUI() => isKSPGUIActive = true;
 
-        void HideGUI()
+        void HideGUI() => isKSPGUIActive = false;
+
+        void OnDestroy()
         {
-            isKSPGUIActive = false;
+            GameEvents.onShowUI.Remove(ShowGUI);
+            GameEvents.onHideUI.Remove(HideGUI);
         }
 
         void OnMouseDown()

--- a/ShowFPS/ShowFPS.cs
+++ b/ShowFPS/ShowFPS.cs
@@ -57,12 +57,10 @@ namespace ShowFPS
     {
         new bool enabled = false;
         internal static float frequency = 0.5f;
+        private bool isKSPGUIActive = true;
 
         float curFPS;
-
-
         bool drag;
-
         Text guiText;
 
         void Awake()
@@ -70,8 +68,20 @@ namespace ShowFPS
             StartCoroutine(FPS());
             guiText = gameObject.GetComponent<Text>();
             guiText.enabled = false;
+
+            GameEvents.onShowUI.Add(ShowGUI);
+            GameEvents.onHideUI.Add(HideGUI);
         }
 
+        void ShowGUI()
+        {
+            isKSPGUIActive = true;
+        }
+
+        void HideGUI()
+        {
+            isKSPGUIActive = false;
+        }
         void OnMouseDown()
         {
             //Debug.Log("[ShowFPS: OnMouseDown");
@@ -94,7 +104,7 @@ namespace ShowFPS
 #endif
         void Update()
         {
-#if fasle
+#if false
             if (cnt++ == 100)
             {
                 Debug.Log("[ShowFPS]: x, y: " +  Settings.position_x + ", " + Settings.position_y);
@@ -184,23 +194,22 @@ namespace ShowFPS
         GUIStyle timeLabelStyle = null;
         public void OnGUI()
         {
-            if (enabled)
+            if (!isKSPGUIActive || !enabled)
+                return;
+
+            if (timeLabelStyle == null)
             {
-                if (timeLabelStyle == null)
-                {
-                    timeLabelStyle = new GUIStyle(GUI.skin.label);
-                }
-                Vector2 size = timeLabelStyle.CalcSize(new GUIContent(curFPS.ToString("F2")));
-
-                //fpsPos.Set(x, y , 200f, size.y);
-                fpsPos.Set(x, y, size.x, size.y);
-
-                if (curFPS > 60)
-                    DrawOutline(0, fpsPos, Math.Round(curFPS).ToString("F0") + " fps", 1, timeLabelStyle, Color.black, Color.white);
-                else
-                    DrawOutline(0, fpsPos, Math.Round(curFPS, 1).ToString("F1") + " fps", 1, timeLabelStyle, Color.black, Color.white);
+                timeLabelStyle = new GUIStyle(GUI.skin.label);
             }
+            Vector2 size = timeLabelStyle.CalcSize(new GUIContent(curFPS.ToString("F2")));
 
+            //fpsPos.Set(x, y , 200f, size.y);
+            fpsPos.Set(x, y, size.x, size.y);
+
+            if (curFPS > 60)
+                DrawOutline(0, fpsPos, Math.Round(curFPS).ToString("F0") + " fps", 1, timeLabelStyle, Color.black, Color.white);
+            else
+                DrawOutline(0, fpsPos, Math.Round(curFPS, 1).ToString("F1") + " fps", 1, timeLabelStyle, Color.black, Color.white);
         }
 
         IEnumerator FPS()

--- a/ShowFPS/ShowFPS.cs
+++ b/ShowFPS/ShowFPS.cs
@@ -82,6 +82,7 @@ namespace ShowFPS
         {
             isKSPGUIActive = false;
         }
+
         void OnMouseDown()
         {
             //Debug.Log("[ShowFPS: OnMouseDown");


### PR DESCRIPTION
[0.3.0.1](https://github.com/linuxgurugamer/ShowFPS/releases/tag/0.3.0.1) added the ability for the Graph GUI to hide when KSP's UI was toggled, but that feature was never added to the FPS Counter GUI. This has made it quite annoying for me, as I have to keep hitting F8 to turn the FPS counter on and off when I want to take a picture. This PR also updates the README.

Before: (upon hitting F2)
![image](https://github.com/user-attachments/assets/708adc01-777c-40d2-9b32-86715425f97e)


After: (upon hitting F2)
![image](https://github.com/user-attachments/assets/f3018bc5-efe0-4fe5-a607-e6e26be2654d)


.dll is [here](https://github.com/Clayell/ShowFPS/releases/tag/0.3.1.3) if anyone is too impatient to wait until the next release