### PR TITLE
Add a way to prevent the FPS counter from moving

### DIFF
--- a/GameData/ShowFPS/Localization/en-us.cfg
+++ b/GameData/ShowFPS/Localization/en-us.cfg
@@ -12,6 +12,7 @@ Localization
         #LOC_ShowFPS_Refresh = Refresh
         #LOC_ShowFPS_Clear = Clear
         #LOC_ShowFPS_Rescale = Rescale
+        #LOC_ShowFPS_Lock_FPS_Counter = Lock Movable FPS Counter
         #LOC_ShowFPS_Show_Max_Symrate = Show Max Symrate
         #LOC_ShowFPS_Periodic_auto_rescale = Periodic auto-rescale
         #LOC_ShowFPS_0 =  0

--- a/GameData/ShowFPS/Localization/en-us.csv
+++ b/GameData/ShowFPS/Localization/en-us.csv
@@ -8,6 +8,7 @@
 "LOC_ShowFPS_Refresh","Refresh"
 "LOC_ShowFPS_Clear","Clear"
 "LOC_ShowFPS_Rescale","Rescale"
+"LOC_ShowFPS_Lock_FPS_Counter","Lock Movable FPS Counter"
 "LOC_ShowFPS_Show_Max_Symrate","Show Max Symrate"
 "LOC_ShowFPS_Periodic_auto_rescale","Periodic auto-rescale"
 "LOC_ShowFPS_0"," 0"

--- a/ShowFPS/Graph.cs
+++ b/ShowFPS/Graph.cs
@@ -224,6 +224,7 @@ namespace ShowFPS
             }
             else
             {
+                lockFPScounter = Settings.lockFPScounter;
                 showPerfectSym = Settings.showPerfectSym;
                 periodicRescale = Settings.periodicRescale;
                 Alpha = Settings.alpha;
@@ -418,6 +419,7 @@ namespace ShowFPS
             }
         }
 
+        bool lockFPScounter = false;
         bool showPerfectSym = false;
         bool periodicRescale = false;
         double lastRescaleTime = 0;
@@ -461,9 +463,12 @@ namespace ShowFPS
             }
             GUILayout.EndHorizontal();
             GUILayout.BeginHorizontal();
-            var oShowPerfectSym = showPerfectSym;
-            var oPeriodicRescale = periodicRescale;
+            bool oLockFPScounter = lockFPScounter;
+            bool oShowPerfectSym = showPerfectSym;
+            bool oPeriodicRescale = periodicRescale;
 
+            lockFPScounter = GUILayout.Toggle(lockFPScounter, Localizer.Format("#LOC_ShowFPS_Lock_FPS_Counter"));
+            GUILayout.FlexibleSpace();
             showPerfectSym = GUILayout.Toggle(showPerfectSym, Localizer.Format("#LOC_ShowFPS_Show_Max_Symrate"));
             GUILayout.FlexibleSpace();
             periodicRescale = GUILayout.Toggle(periodicRescale, Localizer.Format("#LOC_ShowFPS_Periodic_auto_rescale"));
@@ -523,7 +528,8 @@ namespace ShowFPS
             this.resizeHandle.Draw(ref this.windowPos);
 
             GUI.DragWindow(windowDragRect);
-            if (oShowPerfectSym != showPerfectSym ||
+            if (oLockFPScounter != lockFPScounter ||
+                oShowPerfectSym != showPerfectSym ||
                 oPeriodicRescale != periodicRescale ||
                 oAlpha != Alpha ||
                 oFreq != FPSCounter.frequency)
@@ -534,13 +540,14 @@ namespace ShowFPS
 
         void SaveWinSettings()
         {
-                Settings.showPerfectSym = showPerfectSym;
-                Settings.periodicRescale = periodicRescale;
-                Settings.alpha = Alpha;
-                Settings.frequency = FPSCounter.frequency;
-                Settings.winX = windowPos.x;
-                Settings.winY = windowPos.y;
-                Settings.SaveConfig();
+            Settings.lockFPScounter = lockFPScounter;
+            Settings.showPerfectSym = showPerfectSym;
+            Settings.periodicRescale = periodicRescale;
+            Settings.alpha = Alpha;
+            Settings.frequency = FPSCounter.frequency;
+            Settings.winX = windowPos.x;
+            Settings.winY = windowPos.y;
+            Settings.SaveConfig();
         }
 
         float Alpha = 1;

--- a/ShowFPS/Settings.cs
+++ b/ShowFPS/Settings.cs
@@ -28,6 +28,7 @@ namespace ShowFPS
         internal static KeyCode keyScaleUp;
         internal static KeyCode keyScaleDown;
 
+        internal static bool lockFPScounter;
         internal static bool showPerfectSym;
         internal static bool periodicRescale = false;
         internal static float frequency = 0.5f;
@@ -45,7 +46,7 @@ namespace ShowFPS
             keyScaleUp = GetValue("keyScaleUp", KeyCode.KeypadPlus);
             keyScaleDown = GetValue("keyScaleDown", KeyCode.KeypadMinus);
 
-
+            lockFPScounter = GetValue("lockFPScounter", false);
             showPerfectSym = GetValue("showPerfectSym", false);
             periodicRescale = GetValue("periodicRescale", false);
             frequency = GetValue("frequency", 0.5f);
@@ -67,6 +68,7 @@ namespace ShowFPS
             SetValue("plugin_key", PluginKeys.PLUGIN_TOGGLE.primary.ToString());
             SetValue("fontSize", fontSize);
 
+            SetValue("lockFPScounter", lockFPScounter);
             SetValue("showPerfectSym", showPerfectSym);
             SetValue("periodicRescale", periodicRescale);
             SetValue("frequency", frequency);

--- a/ShowFPS/ShowFPS.cs
+++ b/ShowFPS/ShowFPS.cs
@@ -108,7 +108,7 @@ namespace ShowFPS
                 cnt = 0;
             }
 #endif
-            if (drag)
+            if (drag && !Settings.lockFPScounter)
             {
                 x = Input.mousePosition.x;
                 y = (Screen.height - Input.mousePosition.y);


### PR DESCRIPTION
<img width="919" height="859" alt="image" src="https://github.com/user-attachments/assets/2a8c2320-36eb-466f-97a0-636f8b6dfc3a" />
Tested as working ingame (also saves/loads correctly)

<img width="312" height="294" alt="image" src="https://github.com/user-attachments/assets/5c0623e2-392d-4fae-8962-dfc2a6ced655" />